### PR TITLE
Fix JSON serialization outside of zip

### DIFF
--- a/src/bin/parser.rs
+++ b/src/bin/parser.rs
@@ -203,8 +203,7 @@ fn main() {
                         ),
                     }
                 } else {
-                    let v = serde_json::to_value(&parsed_oca_list).unwrap();
-                    println!("{v}");
+                    println!("{}", serde_json::to_string(&parsed_oca_list).unwrap());
                 }
             } else {
                 println!(


### PR DESCRIPTION
By serializing to `serde_json::Value` first, the attributes were getting reordered (sorted) which breaks the digest calculation. @swcurran